### PR TITLE
Change the llava-rad link to the correct code repo of the proposed model

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We collect existing papers on radiology report generation published in prominent
 
 **Nature Communications'25**
 - Towards a holistic framework for multimodal LLM in 3D brain CT radiology report generation [[paper](https://www.nature.com/articles/s41467-025-57426-0)]
-- A clinically accessible small multimodal radiology model and evaluation metric for chest X-ray findings [[paper](https://www.nature.com/articles/s41467-025-58344-x)][[code](https://github.com/microsoft/chexprompt)]
+- A clinically accessible small multimodal radiology model and evaluation metric for chest X-ray findings [[paper](https://www.nature.com/articles/s41467-025-58344-x)][[code](https://github.com/microsoft/llava-rad)][[metric](https://github.com/microsoft/chexprompt)]
 - Generating dermatopathology reports from gigapixel whole slide images with HistoGPT [[paper](https://www.nature.com/articles/s41467-025-60014-x)]
 
 **TPAMI'25**


### PR DESCRIPTION
The current link is directed to the metric link. The code link (train + evaluation) of the proposed method llava-rad is at another link. So i changed it to the correct one. 